### PR TITLE
Fix failing HTTP GET to /undefined if the image attribute is undefined

### DIFF
--- a/jquery-textntags.js
+++ b/jquery-textntags.js
@@ -516,7 +516,10 @@
                 var tagItem, localTag = objPropTransformer(tag, false);
                 localTag.title = utils.highlightTerm(utils.htmlEncode((localTag.title)), query);
                 tagItem = $(templates.tagsListItem(localTag)).data('tag', tag);
-                tagItem = tagItem.prepend(imgOrIconTpl(localTag)).appendTo(tagsDropDown);
+                if(localTag.img) {
+                  tagItem = tagItem.prepend(imgOrIconTpl(localTag));
+                }
+                tagItem.appendTo(tagsDropDown);
 
                 if (index === 0) { 
                     selectTagListItem(tagItem, trigger.classes.tagActiveDropDown);


### PR DESCRIPTION
we're using the code from the basic example with the following 'data' in onDataRequest:

[{
  "id": 173,
  "name": "Admin Huber",
  "type": "user"
}, {
  "id": "177",
  "name": "Bob",
  "type": "user"
}]

when i enter '@' followed by, e.g., 'Bo' an HTTP GET to current_path/undefined is triggered. to prevent this from happening i'm checking whether localTag.img exists inside the populateTagList function.

i'm very unfamiliar with the inner working of textntags and fixed this to the best of my knowledge, feel free to improve my code. couldn't find any report of this issue anywhere else.

cheers, Paul
