### PR TITLE
Compatibility with jQuery 1.9 and changes to dropdown position

### DIFF
--- a/jquery-textntags.css
+++ b/jquery-textntags.css
@@ -40,8 +40,6 @@
   background: #fff;
   border: 1px solid #b2b2b2;
   position: absolute;
-  left: 0;
-  right: 0;
   z-index: 10000;
   margin-top: -2px;
 
@@ -61,6 +59,7 @@
 
 .textntags-wrapper .textntags-tag-list li {
   background-color: #fff;
+  color: black;
   padding: 0 5px;
   margin: 0;
   width: auto;


### PR DESCRIPTION
These two commits make the plugin compatible with jQuery 1.9 by removing the reference to $.browser, and move the tag list dropdown close to the tag being edited by the user.

I'm sure more tweaking is necessary but I think it can be a start. Please let me know if any changes are needed.
