### PR TITLE
If the user digits html tags everything is messed up

### DIFF
--- a/jquery-textntags.js
+++ b/jquery-textntags.js
@@ -159,7 +159,7 @@
         
         function getBeautifiedText (tagged_text) {
             var beautified_text = tagged_text || getTaggedText();
-
+	    beautified_text = beautified_text.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
             _.each(settings.triggers, function (trigger) {
                 var markup = templates.tagHighlight({idx: trigger.parserGroups.title, class_name: trigger.classes.tagHighlight});
                 beautified_text = beautified_text.replace(trigger.parser, markup);


### PR DESCRIPTION
I think is correct to escape html characters. If the user types something like
<div style="height:100px">Hello man!</div> in the textare everything is messed up.
With this patch we escape html characters
